### PR TITLE
Add support for user queries

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,9 @@ Any suggestions are welcomed.
 
 ### Changelog
 
+0.0.8 (Future)
+- Added support for user queries. Props @acobster
+
 0.0.7 (2018-06-27)
 - Fixed #10. Use ^1.0.0 for composer installer. Props @wujekbogdan
 

--- a/src/GeoQueryContext.php
+++ b/src/GeoQueryContext.php
@@ -64,20 +64,8 @@ class GeoQueryContext
             // Run this filter callback only once:
             remove_filter( current_filter(), array( $this, __FUNCTION__ ) );
 
-            // Default implementation:
-            $class = __NAMESPACE__ . '\\GeoQueryHaversine';
-
-            // Check if the user wants another implementation:
-            if( ! empty( $geo_query['context'] ) )
-                $class = preg_replace( '/[^a-z0-9\\\]+/i', '', $geo_query['context'] );
-
-            // Create an implementation instance, if the class exists and implements the GeoQueryInterface interface:
-            if( class_exists( $class ) && in_array( __NAMESPACE__ . '\\GeoQueryInterface', class_implements( $class ) ) )
-            {
-                $g = new $class;
-                $g->setup( $this->db, $geo_query );
-                $clauses = $g->algorithm( $clauses );
-            }
+            // Filter the query clauses:
+            $clauses = $this->get_query_clauses( $geo_query, $clauses );
         }
         return $clauses;
     }

--- a/src/GeoQueryContext.php
+++ b/src/GeoQueryContext.php
@@ -38,7 +38,8 @@ class GeoQueryContext
 
     public function activate()
     {
-     	add_filter( 'posts_clauses', array( $this, 'posts_clauses' ), 99, 2 );
+        add_filter( 'posts_clauses', array( $this, 'posts_clauses' ), 99, 2 );
+        add_action( 'pre_user_query', array( $this, 'pre_user_query' ), 99, 2 );
         return $this;
     }
 
@@ -79,6 +80,55 @@ class GeoQueryContext
             }
         }
         return $clauses;
+    }
+
+    public function pre_user_query( \WP_User_Query $q ) {
+        // get user input
+        $geo_query = $q->get('geo_query');
+
+        if (is_array($geo_query) && ! empty( $geo_query )) {
+
+            // get the existing clauses
+            $clauses = array(
+                'fields'  => $q->query_fields,
+                'from'    => $q->query_from,
+                'where'   => $q->query_where,
+                'orderby' => $q->query_orderby,
+            );
+
+            // override default context explictly for a user query
+            if (empty($geo_query['context'])) {
+                $geo_query['context'] = __NAMESPACE__ . '\\GeoQueryUserHaversine';
+            }
+
+            // get new values for each clause
+            $clauses = $this->get_query_clauses( $geo_query, $clauses );
+
+            // replace clauses in the running query
+            $q->query_fields  = $clauses['fields'];
+            $q->query_from    = $clauses['from'];
+            $q->query_where   = $clauses['where'];
+            $q->query_orderby = $clauses['orderby'];
+        }
+    }
+
+    protected function get_query_clauses( array $geo, array $clauses ) {
+      // Default implementation:
+      $class = __NAMESPACE__ . '\\GeoQueryHaversine';
+
+      // Check if the user wants another implementation:
+      if( ! empty( $geo['context'] ) )
+          $class = preg_replace( '/[^a-z0-9\\\]+/i', '', $geo['context'] );
+
+      // Create an implementation instance, if the class exists and implements the GeoQueryInterface interface:
+      if( class_exists( $class ) && in_array( __NAMESPACE__ . '\\GeoQueryInterface', class_implements( $class ) ) )
+      {
+          $g = new $class;
+          $g->setup( $this->db, $geo );
+          $clauses = $g->algorithm( $clauses );
+      }
+
+      return $clauses;
     }
 
 } // end class

--- a/src/GeoQueryUserHaversine.php
+++ b/src/GeoQueryUserHaversine.php
@@ -1,0 +1,205 @@
+<?php
+
+namespace Birgir\Geo;
+
+/**
+ * The Geo Query User Haversine class
+ *
+ * @uses the Ollie Jones Haversine SQL query: http://www.plumislandmedia.net/mysql/haversine-mysql-nearest-loc/
+ *
+ * @since 0.0.8
+ */
+
+
+class GeoQueryUserHaversine implements GeoQueryInterface
+{
+    private $db;
+    private $lat;
+    private $lng;
+    private $lat_meta_key;
+    private $lng_meta_key;
+    private $distance_unit;
+    private $radius;
+
+
+   /**
+    * Setup - let's implement the interface
+    *
+    * @since 0.0.8
+    *
+    * @param  wpdb     $db         An instance of the wpdb class
+    * @param  array    $geo_query  The geo_query part of the WP_Query
+    * @return GeoQuery $this       An instance of the GeoQuery class
+    */
+
+    public function setup( \wpdb $db, $geo_query = array() )
+    {
+     	$this->db = $db;
+
+        // Default user input:
+        $default = array(
+            'lat_meta_key'       => 'lat',
+            'lng_meta_key'       => 'lng',
+            'lat'                => 0,
+            'lng'                => 0,
+            'radius'             => 0,
+            'distance_unit'      => 111.045,
+            'order'              => '',
+            'context'            => '',
+        );
+        $geo_query = wp_parse_args( $geo_query, $default );
+
+         // Sanitize the user input:
+         $this->lat_meta_key  = sanitize_key( $geo_query['lat_meta_key'] );
+         $this->lng_meta_key  = sanitize_key( $geo_query['lng_meta_key'] );
+         $this->lat           = floatval( $geo_query['lat'] );
+         $this->lng           = floatval( $geo_query['lng'] );
+         $this->radius        = floatval( $geo_query['radius'] );
+         $this->distance_unit = floatval( $geo_query['distance_unit'] );
+         $this->order         = in_array( strtoupper( $geo_query['order'] ), array( 'ASC', 'DESC' ) ) ? strtoupper( $geo_query['order'] ) : '';
+    }
+
+
+   /**
+    * Algorithm - let's implement the interface
+    *
+    * @since 0.0.8
+    *
+    * @param  array    $clauses
+    * @return array    $clauses
+    */
+
+    public function algorithm( $clauses = array() )
+    {
+         // Modify SQL query parts:
+         $clauses['fields']  = $this->users_fields(  $clauses['fields']  );
+         $clauses['where']   = $this->users_where(   $clauses['where']   );
+         $clauses['from']    = $this->users_from(    $clauses['from']    );
+
+         // honor the orderby param
+         $orderby = isset( $clauses['orderby'] ) ? $clauses['orderby'] : '';
+         if( $this->order )
+             $clauses['orderby'] = $this->users_orderby( $orderby );
+
+        return $clauses;
+    }
+
+
+   /**
+    * Modify the SQL for the fields clause
+    *
+    * @since 0.0.8
+    *
+    * @param  string $fields
+    * @return string $fields
+    */
+
+    protected function users_fields( $fields )
+    {
+     	  $fields .= ", settings.distance_unit * DEGREES( ACOS(
+                   COS( RADIANS( settings.latpoint ) )
+                 * COS( RADIANS( mtlat.meta_value ) )
+                 * COS( RADIANS( settings.longpoint ) - RADIANS( mtlng.meta_value ) )
+                 + SIN( RADIANS( settings.latpoint ) )
+                 * SIN( RADIANS( mtlat.meta_value )))) AS distance_value ";
+
+        return $fields;
+    }
+
+
+   /**
+    * Modify the SQL for the where clause
+    *
+    * @since 0.0.8
+    *
+    * @param  string $where
+    * @return string $where
+    */
+
+    protected function users_where( $where )
+    {
+        // check for radius
+        if( $this->radius > 0 ) {
+            // ensure we don't mess up any existing HAVING clause
+            if (strpos($where, ' HAVING ') !== false) {
+                $where .= ' HAVING ';
+            }
+
+            // add the HAVING clause with the radius value
+            $where .= $this->db->prepare(
+                " HAVING distance_value <= %f ",
+                $this->radius
+            );
+        }
+
+        return $where;
+    }
+
+
+   /**
+    * Modify the SQL for the HAVING clause
+    *
+    * @since 0.0.8
+    *
+    * @return string $having
+    */
+
+    protected function users_having()
+    {
+        return $this->db->prepare(
+            " HAVING distance_value <= %f ",
+            $this->radius
+        );
+    }
+
+
+   /**
+    * Modify the SQL for the FROM/JOIN clauses
+    *
+    * @since 0.0.8
+    *
+    * @param  string $from
+    * @return string $from
+    */
+
+    protected function users_from( $from )
+    {
+     	$from .= $this->db->prepare(
+            " INNER JOIN {$this->db->usermeta} AS mtlat ON ( {$this->db->users}.ID = mtlat.user_id AND mtlat.meta_key = '%s' ) ",
+            $this->lat_meta_key
+        );
+
+        $from .= $this->db->prepare(
+            " INNER JOIN {$this->db->usermeta} AS mtlng ON ( {$this->db->users}.ID = mtlng.user_id AND mtlng.meta_key = '%s' ) ",
+            $this->lng_meta_key
+        );
+
+        $from .= $this->db->prepare(
+            " INNER JOIN ( SELECT %f AS latpoint,  %f AS longpoint, %f AS distance_unit, %f AS radius ) AS settings ",
+            $this->lat,
+            $this->lng,
+            $this->distance_unit,
+            $this->radius
+        );
+
+        return $from;
+    }
+
+
+   /**
+    * Modify the SQL for the orderby clause
+    *
+    * @since 0.0.8
+    *
+    * @param  string $orderby
+    * @return string $orderby
+    */
+
+    protected function users_orderby( $orderby )
+    {
+     	return ' distance_value ' . $this->order . ', ' . $orderby;
+    }
+
+
+} // end class
+

--- a/tests/test-geo-query.php
+++ b/tests/test-geo-query.php
@@ -272,6 +272,46 @@ class Test_Geo_Query extends WP_UnitTestCase {
 		$this->assertSame( 1881 , (int) $query->posts[0]->distance_value );
 	}
 
+  public function test_1_km_user_query() {
+    $u1 = self::factory()->user->create( array(
+      'first_name' => 'Site',
+      'last_name'  => 'Crafting',
+    ));
+    add_user_meta( $u1, 'my_lat', 47.236567 );
+    add_user_meta( $u1, 'my_lng', -122.4357428 );
+
+    $u2 = self::factory()->user->create( array(
+      'first_name' => 'Point',
+      'last_name'  => 'Defiance',
+    ));
+    add_user_meta( $u2, 'my_lat', 47.3048779 );
+    add_user_meta( $u2, 'my_lng', -122.5230098 );
+
+    $u3 = self::factory()->user->create( array(
+      'first_name' => 'Space',
+      'last_name'  => 'Needle',
+    ));
+    add_user_meta( $u3, 'my_lat', 47.6205099 );
+    add_user_meta( $u3, 'my_lng', -122.3514661 );
+
+    $args = array(
+      'role'      => 'subscriber',
+      'geo_query' => array(
+        'lat'          => 47.236,
+        'lng'          => -122.435,
+        'lat_meta_key' => 'my_lat',
+        'lng_meta_key' => 'my_lng',
+        'radius'       => 1,
+        'context'      => '\\Birgir\\Geo\\GeoQueryUserHaversine',
+      ),
+    );
+
+    $query = new WP_User_Query( $args );
+
+    $this->assertSame( 1, count($query->results) );
+    $this->assertSame( 'Site', $query->results[0]->first_name );
+  }
+
 	/**
 	 * Callback to apply a geo query.
 	 *


### PR DESCRIPTION
Thanks for this awesome plugin!

This adds support for querying users by their lat/lng data. The public interface is exactly the same, but because `WP_User_Query` internals don't use a specific clause-based hook like `posts_clauses`, I defined a new hook in `activate` and replaced each clause one by one. The new implementation lives in `Birgir\Geo\GeoQueryUserHaversine`.